### PR TITLE
chore: promote python-http2 to version 0.0.1

### DIFF
--- a/helmfile.yaml
+++ b/helmfile.yaml
@@ -2,5 +2,6 @@ filepath: ""
 helmfiles:
 - path: helmfiles/jx/helmfile.yaml
 - path: helmfiles/tekton-pipelines/helmfile.yaml
+- path: helmfiles/jx-staging/helmfile.yaml
 templates: {}
 renderedvalues: {}

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -1,0 +1,11 @@
+filepath: ""
+namespace: jx-staging
+repositories:
+- name: dev
+  url: http://bucketrepo-jx.n8m.nl
+releases:
+- chart: dev/python-http2
+  version: 0.0.1
+  name: python-http2
+templates: {}
+renderedvalues: {}


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# python-http2

## Changes in version 0.0.1

### Chores

* release 0.0.1 (jenkins-x-bot)
* add variables (jenkins-x-bot)
* Jenkins X build pack (N Glerum)
