### PR TITLE
chore: promote py-http to version 0.0.2

### DIFF
--- a/config-root/namespaces/jx-staging/py-http/py-http-py-http-deploy.yaml
+++ b/config-root/namespaces/jx-staging/py-http/py-http-py-http-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: py-http-py-http
   labels:
     draft: draft-app
-    chart: "py-http-0.0.1"
+    chart: "py-http-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'py-http'
@@ -25,11 +25,11 @@ spec:
       serviceAccountName: py-http-py-http
       containers:
       - name: py-http
-        image: "ghcr.io/nigle-dev/py-http:0.0.1"
+        image: "ghcr.io/nigle-dev/py-http:0.0.2"
         imagePullPolicy: IfNotPresent
         env:
         - name: VERSION
-          value: 0.0.1
+          value: 0.0.2
         envFrom: null
         ports:
         - name: http

--- a/config-root/namespaces/jx-staging/py-http/py-http-svc.yaml
+++ b/config-root/namespaces/jx-staging/py-http/py-http-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: py-http
   labels:
-    chart: "py-http-0.0.1"
+    chart: "py-http-0.0.2"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   annotations:
     meta.helm.sh/release-name: 'py-http'

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,7 +73,7 @@
 	    <tr>
 	      <td>py-http</td>
 	      <td title='A Helm chart for Kubernetes'> <img src='https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png' width='24px' height='24px'> py-http</td>
-	      <td>0.0.1</td>
+	      <td>0.0.2</td>
 	      <td></td>
 	      <td></td>
 	    </tr>

--- a/docs/releases.yaml
+++ b/docs/releases.yaml
@@ -104,14 +104,14 @@
   path: helmfiles/jx-staging/helmfile.yaml
   releases:
   - apiVersion: v1
-    appVersion: 0.0.1
+    appVersion: 0.0.2
     description: A Helm chart for Kubernetes
-    firstDeployed: "2023-01-26T11:47:58Z"
+    firstDeployed: "2023-01-26T12:44:28Z"
     icon: https://raw.githubusercontent.com/cdfoundation/artwork/master/jenkinsx/icon/color/jenkinsx-icon-color.png
-    lastDeployed: "2023-01-26T11:47:58Z"
+    lastDeployed: "2023-01-26T12:44:28Z"
     name: py-http
     releaseName: py-http
     repositoryName: dev
     repositoryUrl: http://bucketrepo-jx.n8m.nl/bucketrepo/charts/
     resourcePath: config-root/namespaces/jx-staging/py-http
-    version: 0.0.1
+    version: 0.0.2

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://bucketrepo-jx.n8m.nl/bucketrepo/charts/
 releases:
 - chart: dev/py-http
-  version: 0.0.1
+  version: 0.0.2
   name: py-http
   values:
   - jx-values.yaml


### PR DESCRIPTION
this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge

-----
# py-http

## Changes in version 0.0.2

### Chores

* release 0.0.2 (jenkins-x-bot)
* add variables (jenkins-x-bot)

### Other Changes

These commits did not use [Conventional Commits](https://conventionalcommits.org/) formatted messages:

* updated readme (N Glerum)
